### PR TITLE
Ensure triangulated vertices are not collinear.

### DIFF
--- a/polygon.lua
+++ b/polygon.lua
@@ -319,7 +319,7 @@ function Polygon:triangulate()
 	while n_vert > 3 do
 		next, prev = next_idx[current], prev_idx[current]
 		local p,q,r = vertices[prev], vertices[current], vertices[next]
-		if isEar(p,q,r, concave) then
+		if isEar(p,q,r, concave) and not areCollinear(p, q, r)  then
 			triangles[#triangles+1] = newPolygon(p.x,p.y, q.x,q.y, r.x,r.y)
 			next_idx[prev], prev_idx[next] = next, prev
 			concave[q] = nil


### PR DESCRIPTION
I was running into an issue where, rarely, `Polygon:triangulate()` would find triangles that were comprised of collinear points. Then, when it went to great new sub-Polygons, it would throw an error about the collinear points.

This additional check avoids adding triangles to the list of triangles if they will have no area.

I have included this test case to further illustrate the case I ran into.

``` Lua
local g = love.graphics

function love.load()
  Polygon = require('HC.polygon')

  points = {
    2, 2,
    3, 2,
    3, 3,
    1, 3,
    1, 2,
    0, 2,
    0, 1,
    2, 1
  }

  for index,point in ipairs(points) do
    points[index] = point * 100
  end

  polygon = Polygon(unpack(points))
  triangles = polygon:triangulate()
end

function love.draw()
  g.translate(100, 0)
  for i,triangle in ipairs(triangles) do
    local x1, y1, x2, y2, x3, y3 = triangle:unpack()
    local x, y = (x1 + x2 + x3) / 3, (y1 + y2 + y3) / 3

    g.setColor(255, 255, 255)
    g.polygon('line', x1, y1, x2, y2, x3, y3)
    g.setColor(255, 0, 0)
    g.circle('fill', x, y, 5)
    g.print(i, x, y)
  end
end
```
