### PR TITLE
Performance and memory improvements in GJK

### DIFF
--- a/gjk.lua
+++ b/gjk.lua
@@ -62,7 +62,7 @@ end
 
 local function EPA(shape_a, shape_b)
 	-- make sure simplex is oriented counter clockwise
-	local cx,cy, bx,by, ax,ay = unpack(simplex)
+	local cx,cy, bx,by, ax,ay = unpack(simplex, 1, 6)
 	if vector.dot(ax-bx,ay-by, cx-bx,cy-by) < 0 then
 		simplex[1],simplex[2] = ax,ay
 		simplex[5],simplex[6] = cx,cy
@@ -96,7 +96,7 @@ end
 -- B o------o A   since A is the furthest point on the MD
 --   :      :     in direction of the origin.
 local function do_line()
-	local bx,by, ax,ay = unpack(simplex)
+	local bx,by, ax,ay = unpack(simplex, 1, 4)
 
 	local abx,aby = bx-ax, by-ay
 
@@ -105,7 +105,7 @@ local function do_line()
 	if vector.dot(dx,dy, -ax,-ay) < 0 then
 		dx,dy = -dx,-dy
 	end
-	return 4, dx,dy
+	return dx,dy
 end
 
 -- B .'
@@ -116,7 +116,7 @@ end
 --  o-'  3
 -- C '.
 local function do_triangle()
-	local cx,cy, bx,by, ax,ay = unpack(simplex)
+	local cx,cy, bx,by, ax,ay = unpack(simplex, 1, 6)
 	local aox,aoy = -ax,-ay
 	local abx,aby = bx-ax, by-ay
 	local acx,acy = cx-ax, cy-ay

--- a/gjk.lua
+++ b/gjk.lua
@@ -83,9 +83,11 @@ local function EPA(shape_a, shape_b)
 		last_diff_dist = diff_dist
 
 		-- simplex = {..., simplex[e.i-1], px, py, simplex[e.i]
-		table.insert(simplex, e.i, py)
-		table.insert(simplex, e.i, px)
-
+		for i = n, e.i, -1 do
+			simplex[i+2] = simplex[i]
+		end
+		simplex[e.i+0] = px
+		simplex[e.i+1] = py
 		n = n + 2
 	end
 end

--- a/gjk.lua
+++ b/gjk.lua
@@ -36,8 +36,9 @@ local function support(shape_a, shape_b, dx, dy)
 end
 
 -- returns closest edge to the origin
+local edge = {}
 local function closest_edge(n)
-	local e = {dist = huge}
+	edge.dist = huge
 
 	local i = n-1
 	for k = 1,n-1,2 do
@@ -49,14 +50,14 @@ local function closest_edge(n)
 		local nx,ny = vector.normalize(ex,ey)
 		local d = vector.dot(ax,ay, nx,ny)
 
-		if d < e.dist then
-			e.dist = d
-			e.nx, e.ny = nx, ny
-			e.i = k
+		if d < edge.dist then
+			edge.dist = d
+			edge.nx, edge.ny = nx, ny
+			edge.i = k
 		end
 	end
 
-	return e
+	return edge
 end
 
 local function EPA(shape_a, shape_b)


### PR DESCRIPTION
`GJK` allocates a `simplex` table every time it's called, and `closest_edge` allocates many tables in the `EPA` loop.

This resulted in high memory consumption as seen by @pfirsich. Trying to fix this issue we both worked on a way to make the `simplex` and `edge` tables static.

Additionally the `table.insert` was slowing down the iteration so it was changed for a single loop that inserts both values.

Feel free to squash the commits if needed