### PR TITLE
allow passing segments argument to CircleShape:draw()

### DIFF
--- a/docs/Shapes.rst
+++ b/docs/Shapes.rst
@@ -284,6 +284,13 @@ Built-in Shapes
 
 .. class:: CircleShape
 
+.. function:: CircleShape:draw(mode, segments)
+
+    :param DrawMode mode: How to draw the shape. Either 'line' or 'fill'.
+    :param number segments: The number of segments to draw the circle with.
+
+Draw the circle shape either filled or as an outline and with the specified number of segments.
+
 .. class:: PointShape
 
 .. function:: newPolygonShape(...)

--- a/shapes.lua
+++ b/shapes.lua
@@ -418,7 +418,8 @@ function ConcavePolygonShape:draw(mode, wireframe)
 end
 
 function CircleShape:draw(mode, segments)
-	love.graphics.circle(mode or 'line', self:outcircle())
+	local x, y, r = self:outcircle()
+	love.graphics.circle(mode or 'line', x, y, r, segments)
 end
 
 function PointShape:draw()


### PR DESCRIPTION
Seems like a feature that was meant to be, but wasn't quite implemented.