### PR TITLE
Added a function for raycasting.

### DIFF
--- a/docs/MainModule.rst
+++ b/docs/MainModule.rst
@@ -254,6 +254,25 @@ You can iterate over the shapes using ``pairs`` (see example).
         game.selectUnit(s)
     end
 
+.. function:: HC.raycast(x, y, dx, dy, range)
+
+   :param numbers x,y: Origin point of ray
+   :param numbers dx,dy: Direction vector of ray(normal vector)
+   :param number range: Range of raycast
+   :returns: Table of shapes that got hit and its hit points.
+
+Gets shapes that got hit by a given ray and the points which that shape intersects with the ray.
+The table is a *set*, meaning that the shapes are stored in *keys* of the table. The values are the points of intersection. You can iterate over the shapes using ``pairs`` (see example).
+
+**Example**::
+
+    local hits = HC.raycast(originx, originy, directionx, directiony, range)
+    for shape, points in pairs(hits) do
+      for _, point in ipairs(points) do
+        love.graphics.points(point.x, point.y)
+      end
+    end
+
 
 .. function:: HC.hash()
 

--- a/init.lua
+++ b/init.lua
@@ -118,6 +118,27 @@ function HC:collisions(shape)
 	return candidates
 end
 
+function HC:raycast(x, y, dx, dy, range)
+	local dxr, dyr = dx * range, dy * range
+	local bbox = { x + dxr , y + dyr, x, y }
+	local candidates = self._hash:inSameCells(unpack(bbox))
+
+	for col in pairs(candidates) do
+		local intersections = col:intersectionsWithRay(x, y, dx, dy)
+		if #intersections > 0 then
+			for i, intersection in pairs(intersections) do
+				if intersection < 0 or intersection > range then
+					rawset(intersections, i, nil)
+				end
+			end
+			rawset(candidates, col, intersections)
+		else
+			rawset(candidates, col, nil)
+		end
+	end
+	return candidates
+end
+
 function HC:shapesAt(x, y)
 	local candidates = {}
 	for c in pairs(self._hash:cellAt(x, y)) do

--- a/init.lua
+++ b/init.lua
@@ -130,7 +130,7 @@ function HC:raycast(x, y, dx, dy, range)
 				if rparam < 0 or rparam > range then
 					rawset(rparams, i, nil)
 				else
-          local hitx, hity = x + (rparam * dx), y + (rparam * dy)
+					local hitx, hity = x + (rparam * dx), y + (rparam * dy)
 					rawset(rparams, i, { x = hitx, y = hity })
 				end
 			end

--- a/init.lua
+++ b/init.lua
@@ -124,14 +124,17 @@ function HC:raycast(x, y, dx, dy, range)
 	local candidates = self._hash:inSameCells(unpack(bbox))
 
 	for col in pairs(candidates) do
-		local intersections = col:intersectionsWithRay(x, y, dx, dy)
-		if #intersections > 0 then
-			for i, intersection in pairs(intersections) do
-				if intersection < 0 or intersection > range then
-					rawset(intersections, i, nil)
+		local rparams = col:intersectionsWithRay(x, y, dx, dy)
+		if #rparams > 0 then
+			for i, rparam in pairs(rparams) do
+				if rparam < 0 or rparam > range then
+					rawset(rparams, i, nil)
+				else
+          local hitx, hity = x + (rparam * dx), y + (rparam * dy)
+					rawset(rparams, i, { x = hitx, y = hity })
 				end
 			end
-			rawset(candidates, col, intersections)
+			rawset(candidates, col, rparams)
 		else
 			rawset(candidates, col, nil)
 		end


### PR DESCRIPTION
Added a function for easier raycasting. There is `intersectionsWithRay` and `intersectsRay` in shape class and `intersectionsWithSegment` in `SpatialHash` class, But there is no easy interface for doing a simple raycast up until a certain range so I ended up adding this to my fork of project, I think it can help others who want to use this library for all of their physics problems, Which is why I've made this PR.
I'm going to add box cast and circle cast in future as my game progress.
If you guys have any problems with the current implementation I've proposed, just tell me how you guys want it to be so i can do the refactoring.
On another note, I'm going to maintain and add features to this library and make PRs for at least a year or two. if you guys wouldn't mind, It could be great if you remove the `no longer maintained` notice in the README so more people can use this project.